### PR TITLE
fix: test and coverage task for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node ./fuse.js",
-    "test": "TS_NODE_PROJECT=./src/tsconfig.mocha.json mocha  --opts ./test/mocha.opts -G",
-    "coverage": "TS_NODE_PROJECT=./src/tsconfig.mocha.json nyc mocha  --opts ./test/mocha.coverage.opts -G"
+    "test": "set TS_NODE_PROJECT=./src/tsconfig.mocha.json&& mocha  --opts ./test/mocha.opts -G",
+    "coverage": "set TS_NODE_PROJECT=./src/tsconfig.mocha.json&& nyc mocha  --opts ./test/mocha.coverage.opts -G"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
On Windows, you cannot simply assign env variables without using the `set` method or the powershell equivalent `$env`.

So I added `set` before executing the test/coverage task inside the `package.json`