### PR TITLE
fix: fix material beta.2 breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@angular/core": "^2.3.1",
     "@angular/forms": "^2.3.1",
     "@angular/http": "^2.3.1",
-    "@angular/material": "^2.0.0-beta.0",
+    "@angular/material": "^2.0.0-beta.2",
     "@angular/platform-browser": "^2.3.1",
     "@angular/platform-browser-dynamic": "^2.3.1",
     "@angular/router": "^3.3.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
-// import { MaterialModule } from '@angular/material';  // @angular/material currently has a bug, where their package.json points to a non-existing main file.
-import { MaterialModule } from '@angular/material/bundles/material.umd';
+import { MaterialModule } from '@angular/material';
 import { AppComponent } from './app.component';
 import { TodoListComponent } from './todo/todo-list.component';
 import { TodoService } from './todo/todo.service';
@@ -13,7 +12,7 @@ import { TodoItemComponent } from './todo/todo-item.component';
     imports: [
         BrowserModule,
         FormsModule,
-        MaterialModule.forRoot()
+        MaterialModule
     ],
     declarations: [
         AppComponent,

--- a/src/todo/todo-item.component.html
+++ b/src/todo/todo-item.component.html
@@ -1,7 +1,7 @@
 <div class="todo-item">
     <md-checkbox class="checkbox-label" [(ngModel)]="todo.done" *ngIf="!editMode">{{todo.name}}</md-checkbox>
     <md-input-container class="edit-input" *ngIf="editMode">
-        <input md-input [(ngModel)]="todo.name" (keyup)="onKeyUp($event)">
+        <input mdInput [(ngModel)]="todo.name" (keyup)="onKeyUp($event)">
     </md-input-container>
     <button class="menu-button" md-icon-button [mdMenuTriggerFor]="menu">
         <i class="material-icons">more_vert</i>

--- a/src/todo/todo-list.component.html
+++ b/src/todo/todo-list.component.html
@@ -1,7 +1,7 @@
 <h1 class="main-title">Fuse-box NG2 Todo</h1>
 <md-card class="center-card">
     <md-input-container class="full-width">
-        <input md-input placeholder="Add a new todo" [(ngModel)]="newTodo.name" (keyup)="onKeyUp($event)">
+        <input mdInput placeholder="Add a new todo" [(ngModel)]="newTodo.name" (keyup)="onKeyUp($event)">
     </md-input-container>
 </md-card>
 

--- a/src/todo/todo-list.component.scss
+++ b/src/todo/todo-list.component.scss
@@ -17,16 +17,16 @@ todo-list {
     .full-width {
         width: 100%;
     }
-    .md-tab-label {
+    .mat-tab-label {
         width: 33.333333%;
     }
-    md-tab-body {
+    .mat-tab-body {
         padding: 15px 20px;
     }
-    md-card-content {
+    .mat-card-content {
         margin-bottom: 0;
     }
-    md-card-actions {
+    .mat-card-actions {
         margin: 0;
         text-align: right;
     }


### PR DESCRIPTION
While testing fuse-box, I could see that some sutff does not work due to recent breaking changes introduced by material beta.2

Great work, btw! It's blazing fast :+1: 

See https://github.com/angular/material2/blob/master/CHANGELOG.md

Style is now prefixed by mat-
Use mdInput on inputs
MaterialModule.forRoot is deprecated