### PR TITLE
fix: make tests pass again

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node ./fuse.js",
-    "test": "set TS_NODE_PROJECT=./src/tsconfig.mocha.json&& mocha  --opts ./test/mocha.opts -G",
-    "coverage": "set TS_NODE_PROJECT=./src/tsconfig.mocha.json&& nyc mocha  --opts ./test/mocha.coverage.opts -G"
+    "test": "cross-env TS_NODE_PROJECT=./src/tsconfig.mocha.json mocha --opts ./test/mocha.opts -G",
+    "coverage": "cross-env TS_NODE_PROJECT=./src/tsconfig.mocha.json nyc mocha --opts ./test/mocha.coverage.opts -G"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
     "@types/node": "^6.0.52",
     "@types/sinon": "^1.16.34",
     "chai": "^3.5.0",
+    "cross-env": "^3.1.4",
     "fuse-box": "^1.3.117",
     "jsdom-no-contextify": "^3.1.0",
     "mocha": "^3.2.0",

--- a/test/mocha.shim.js
+++ b/test/mocha.shim.js
@@ -1,4 +1,4 @@
-var jsdom = require('jsdom-no-contextify')
+var jsdom = require('jsdom')
 
 var document = jsdom.jsdom('<!doctype html><html><head><title>Mocha Testing Page</title></head><body></body></html>');
 


### PR DESCRIPTION
Use jsdom in mocha.shim
Change the way to pass node env var to mocha by using the cross-env lib

Fixes #17