### PR TITLE
test: do no watch for changes for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ node_js:
   - "6"
 install:
   - npm install
-  - npm test

--- a/README.md
+++ b/README.md
@@ -17,5 +17,7 @@ See the working demo [here](https://fuse-box.github.io/angular2-example/)!
 #### Setup & run
 * `npm install`
 * `npm start`
+* `npm test`: run tests
+* `npm test:auto`: run tests and watch files to re run tests
 
 Visit `http://localhost:4445/`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prestart": "rimraf dist && cpx ./src/index.html ./dist/",
     "start": "node ./fuse.js",
-    "test": "cross-env TS_NODE_PROJECT=./src/tsconfig.mocha.json mocha --opts ./test/mocha.opts -G",
+    "test": "cross-env TS_NODE_PROJECT=./src/tsconfig.mocha.json mocha --opts ./test/mocha.travis.opts",
+    "test:auto": "cross-env TS_NODE_PROJECT=./src/tsconfig.mocha.json mocha --opts ./test/mocha.opts -G",
     "coverage": "cross-env TS_NODE_PROJECT=./src/tsconfig.mocha.json nyc mocha --opts ./test/mocha.coverage.opts -G"
   },
   "repository": {

--- a/test/mocha.travis.opts
+++ b/test/mocha.travis.opts
@@ -1,0 +1,4 @@
+--compilers ts-node/register
+--full-trace
+--require ./test/mocha.shim.js
+./src/**/*.spec.ts


### PR DESCRIPTION
As travis runs `npm test` by default. I created a `test:auto` task to watch files and re run tests.
Then, tests will not hang indefinetaly.

I add a section about tests in the README.